### PR TITLE
Fix: handle input value 0 in FizzBuzz solution

### DIFF
--- a/100/101/05-fizzbuzz/solution/fb.go
+++ b/100/101/05-fizzbuzz/solution/fb.go
@@ -3,6 +3,9 @@ package fizzbuzz
 import "fmt"
 
 func Check(n int) (result string) {
+	if n == 0 {
+		return "0"
+	}
 	if n%3 == 0 && n%5 == 0 {
 		return "FizzBuzz"
 	}


### PR DESCRIPTION
Fixed the failing test case for input 0 in go-workshop/100/101/05-fizzbuzz/solution/fb.go by updating the logic to correctly handle this edge case.